### PR TITLE
fix(package): tag name

### DIFF
--- a/.github/workflows/build-foundry-module.yml
+++ b/.github/workflows/build-foundry-module.yml
@@ -3,7 +3,7 @@ name: Build FoundryVTT Module
 on:
   push:
     tags:
-      - 'foundryvtt-webrtc-mediasoup-v*.*.*'
+      - 'foundryvtt-mediasoup-webrtc-v*.*.*'
 
 permissions:
   contents: write


### PR DESCRIPTION
It appears the repo and package name have a different order of words.
Lets fix this and the repo name.
