### PR TITLE
fix: add missing mediasoup-client dependency to module.json

### DIFF
--- a/module.json.template
+++ b/module.json.template
@@ -17,6 +17,9 @@
     "verified": "13.330",
     "maximum": "13"
   },
+  "scripts": [
+    "https://unpkg.com/mediasoup-client@3/lib/mediasoup-client.js"
+  ],
   "esmodules": [
     "mediasoup-vtt.js"
   ],


### PR DESCRIPTION
## Summary
- Adds `scripts` section to `module.json.template` to load mediasoup-client library from CDN
- Fixes module initialization failure that prevented MediaSoupVTT settings from appearing in FoundryVTT
- Resolves "mediasoup-client library is not loaded" error during module startup

## Technical Details
The module was failing to initialize because `window.mediasoupClient` was undefined, causing the entire module to fail before settings registration. This fix ensures the dependency is loaded before the ES module initializes.

## Test Plan
- [ ] Verify MediaSoupVTT section appears in Game Settings → Configure Settings → Module Settings
- [ ] Check that "Configure MediaSoup Server" button is visible and functional
- [ ] Confirm no console errors related to missing mediasoup-client library
- [ ] Test module initialization in both development and production builds

🤖 Generated with [Claude Code](https://claude.ai/code)