### PR TITLE
fix: correct settings menu registration for configuration dialog

### DIFF
--- a/src/ui/settings.js
+++ b/src/ui/settings.js
@@ -8,7 +8,7 @@ import {
     SETTING_DEFAULT_AUDIO_DEVICE, SETTING_DEFAULT_VIDEO_DEVICE
 } from '../constants/index.js';
 import { log } from '../utils/logger.js';
-import { showConfigDialog } from './configDialog.js';
+import { MediaSoupConfigDialog } from './configDialog.js';
 
 export function registerSettings() {
     // Configuration dialog button
@@ -17,8 +17,8 @@ export function registerSettings() {
         label: 'Configure MediaSoup Server',
         hint: 'Open the comprehensive configuration dialog with setup instructions.',
         icon: 'fas fa-cogs',
-        type: 'button',
-        onClick: () => showConfigDialog()
+        type: MediaSoupConfigDialog,
+        restricted: false
     });
 
     game.settings.register(MODULE_ID, SETTING_DEBUG_LOGGING, {


### PR DESCRIPTION
## Summary
- Fixes settings menu registration to properly display configuration dialog in FoundryVTT
- Replaces invalid `type: 'button'` with correct `MediaSoupConfigDialog` FormApplication class
- Updates import to use `MediaSoupConfigDialog` class instead of `showConfigDialog` function

## Problem
The MediaSoup plugin configuration dialog was not visible in FoundryVTT's module settings because the settings menu was registered incorrectly using `type: 'button'`, which is not a valid type for FoundryVTT settings menus.

## Solution
Changed the settings registration to use the proper FormApplication class pattern that FoundryVTT expects:
- `type: MediaSoupConfigDialog` (FormApplication class)
- Import the class instead of the wrapper function
- Set `restricted: false` for user access

## Test Plan
- [ ] Install module in FoundryVTT development instance  
- [ ] Navigate to Game Settings → Configure Settings → Module Settings
- [ ] Verify MediaSoupVTT section appears with settings
- [ ] Verify "MediaSoup Server Configuration" button opens the comprehensive dialog
- [ ] Test configuration dialog functionality (save, test connection)

🤖 Generated with [Claude Code](https://claude.ai/code)