### PR TITLE
fix: correct FoundryVTT module package structure for proper installation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,19 +46,15 @@ jobs:
       - name: Create FoundryVTT module zip
         if: ${{ steps.release.outputs.release_created }}
         run: |
-          # Create a clean directory with only the files needed for the module
+          # The dist/ directory already contains the complete, correct FoundryVTT module structure
+          # Simply copy all contents to create the proper zip structure
           mkdir -p module-package
           
-          # Copy the main built JavaScript file
-          cp dist/mediasoup-vtt.js module-package/
+          # Copy entire dist directory contents to package root (this gives us the correct structure)
+          cp -r dist/* module-package/
           
-          # Copy the processed module.json (which has correct version and metadata)
-          cp module.json module-package/
-          
-          # Copy required module directories if they exist
-          if [ -d "lang" ]; then cp -r lang/ module-package/; fi
-          if [ -d "styles" ]; then cp -r styles/ module-package/; fi
-          if [ -d "templates" ]; then cp -r templates/ module-package/; fi
+          # Override with the root module.json which has the correct version from release-please
+          cp module.json module-package/module.json
           
           # List contents for debugging
           echo "Module package contents:"


### PR DESCRIPTION
The previous workflow was creating incorrect module structure by selectively copying files. The dist/ directory already contains the complete, correct FoundryVTT module structure.

Changes:
- Use complete dist/ directory contents as package base
- Ensure mediasoup-vtt.js is at zip root (not under dist/)
- Include all required files: .js, .js.map, README.md, lang/, styles/, templates/
- Override with root module.json for correct version metadata
- Simplify packaging logic

This creates the correct structure that FoundryVTT expects: mediasoup-vtt.zip/
├── mediasoup-vtt.js          (at root, not dist/mediasoup-vtt.js)
├── mediasoup-vtt.js.map
├── module.json
├── README.md
├── lang/en.json
├── styles/mediasoup-vtt.css
└── templates/config-dialog.html

Fixes the "file does not exist" error in FoundryVTT module installation.

🤖 Generated with [Claude Code](https://claude.ai/code)