### PR TITLE
fix: resolve settings menu registration test failure

### DIFF
--- a/src/mediasoup-vtt-test.js
+++ b/src/mediasoup-vtt-test.js
@@ -118,7 +118,7 @@ Hooks.once('ready', async () => {
                     await mediaSoupVTTClientInstance._populateDeviceSettings();
                 }
             } catch (e) { 
-                log("Error querying permissions on ready: " + e.message, "warn"); 
+                log('Error querying permissions on ready: ' + e.message, 'warn'); 
             }
         }
     }

--- a/src/mediasoup-vtt.js
+++ b/src/mediasoup-vtt.js
@@ -89,7 +89,7 @@ Hooks.once('ready', async () => {
                     await mediaSoupVTTClientInstance._populateDeviceSettings();
                 }
             } catch (e) { 
-                log("Error querying permissions on ready: " + e.message, "warn"); 
+                log('Error querying permissions on ready: ' + e.message, 'warn'); 
             }
         }
     }

--- a/tests/integration/setup/mock-foundry.js
+++ b/tests/integration/setup/mock-foundry.js
@@ -143,8 +143,38 @@ class MockSettings {
     
     registerMenu(module, key, options) {
         const fullKey = `${module}.${key}`;
-        this.menus.set(fullKey, options);
-        console.log(`[MockFoundry] Registered menu: ${fullKey}`, options);
+        
+        // Manually create the menu object to ensure the type field is preserved
+        // Convert function constructors to their string names for cross-boundary compatibility
+        let typeValue = options.type;
+        if (typeof options.type === 'function') {
+            typeValue = options.type.name || 'Function';
+        }
+        
+        const menu = {
+            name: options.name,
+            label: options.label,
+            hint: options.hint,
+            icon: options.icon,
+            type: typeValue, // Store converted type
+            restricted: options.restricted,
+            key: fullKey
+        };
+        
+        // Remove undefined fields
+        Object.keys(menu).forEach(key => {
+            if (menu[key] === undefined) {
+                delete menu[key];
+            }
+        });
+        
+        this.menus.set(fullKey, menu);
+        console.log(`[MockFoundry] Registered menu: ${fullKey}`, JSON.stringify(options, (key, value) => {
+            if (typeof value === 'function') {
+                return value.name || 'Function';
+            }
+            return value;
+        }));
     }
     
     get(module, key) {


### PR DESCRIPTION
## Summary
- Fixed MockFoundry `registerMenu` method to properly preserve type information
- Converted function constructors to string representations for browser compatibility
- Applied same cross-boundary serialization fix used for settings registration

## Problem
The "should register settings menu correctly" test was failing because the `type` field (which contains a function constructor `MediaSoupConfigDialog`) was being lost when crossing browser boundaries in the testing environment.

## Solution
Applied the same fix pattern used for issue #65:
1. **MockFoundry Fix**: Modified the `registerMenu` method to convert function constructors to string representations
2. **Field Preservation**: Ensured all menu fields including `type` are properly stored and returned by `getAllMenus()`

## Test Results
✅ Test now passes: "should register settings menu correctly"

## Related Issues
- Similar to #65 (settings registration fix)
- Part of comprehensive mock FoundryVTT improvement

Fixes #66

🤖 Generated with [Claude Code](https://claude.ai/code)