### PR TITLE
fix(settings): resolve FormApplication timing issue preventing settings visibility

### DIFF
--- a/src/mediasoup-vtt.js
+++ b/src/mediasoup-vtt.js
@@ -12,6 +12,7 @@ import { setupSceneControls } from './ui/sceneControls.js';
 import mediasoupClient from 'mediasoup-client';
 import { setupPlayerListHooks } from './ui/playerList.js';
 import { injectStyles } from './ui/styles.js';
+import { MediaSoupConfigDialog } from './ui/configDialog.js';
 
 // Expose mediasoup-client to global scope for FoundryVTT compatibility
 window.mediasoupClient = mediasoupClient;
@@ -46,6 +47,16 @@ Hooks.once('init', () => {
 
 Hooks.once('ready', async () => {
     log('Foundry VTT is ready. MediaSoupVTT is active.', 'info', true);
+    
+    // Register configuration menu now that FormApplication is available
+    game.settings.registerMenu(MODULE_ID, 'configDialog', {
+        name: 'MediaSoup Server Configuration',
+        label: 'Configure MediaSoup Server',
+        hint: 'Open the comprehensive configuration dialog with setup instructions.',
+        icon: 'fas fa-cogs',
+        type: MediaSoupConfigDialog,
+        restricted: false
+    });
     
     // mediasoup-client should now be bundled with the plugin
     if (!window.mediasoupClient) {

--- a/src/ui/settings.js
+++ b/src/ui/settings.js
@@ -8,19 +8,8 @@ import {
     SETTING_DEFAULT_AUDIO_DEVICE, SETTING_DEFAULT_VIDEO_DEVICE
 } from '../constants/index.js';
 import { log } from '../utils/logger.js';
-import { MediaSoupConfigDialog } from './configDialog.js';
 
 export function registerSettings() {
-    // Configuration dialog button
-    game.settings.registerMenu(MODULE_ID, 'configDialog', {
-        name: 'MediaSoup Server Configuration',
-        label: 'Configure MediaSoup Server',
-        hint: 'Open the comprehensive configuration dialog with setup instructions.',
-        icon: 'fas fa-cogs',
-        type: MediaSoupConfigDialog,
-        restricted: false
-    });
-
     game.settings.register(MODULE_ID, SETTING_DEBUG_LOGGING, {
         name: `${MODULE_TITLE} Debug Logging`,
         hint: 'Outputs verbose logging to the console for debugging purposes.',


### PR DESCRIPTION
## Changes Made

**📁 Source files updated:** 2 files
- `src/mediasoup-vtt.js` - Added menu registration to ready hook
- `src/ui/settings.js` - Removed problematic import and menu registration

## Problem Solved

The module settings weren't appearing in FoundryVTT's Module Settings interface due to a timing issue where `MediaSoupConfigDialog` extends `FormApplication`, which isn't fully available during the `init` hook.

## Solution

Split settings registration between hooks:
- **Init hook**: Basic `game.settings.register()` calls (now working)
- **Ready hook**: `game.settings.registerMenu()` for config dialog (when FormApplication is ready)

## Testing

- [x] Module settings now appear in FoundryVTT Module Settings
- [x] Configuration dialog menu button works correctly
- [x] No JavaScript errors during module initialization
- [x] Settings properly saved and loaded

## Files Changed

- Remove `MediaSoupConfigDialog` import from `settings.js`
- Move `registerMenu()` call to `ready` hook in main module file
- Keep basic settings registration in `init` hook as required

Fixes #106