### PR TITLE
chore: upgrade blueprint docs (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tests/results/
 
 # Rust build artifacts
 server/target/
+
+# Serena MCP local state (removed from repo in #113)
+.serena/

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,6 +826,29 @@
                 "url": "https://opencollective.com/mediasoup"
             }
         },
+        "node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/braces": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1206,29 +1229,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
@@ -1748,9 +1748,9 @@
             }
         },
         "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1889,9 +1889,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2097,9 +2097,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-            "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2227,35 +2227,17 @@
             }
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
+                "debug": "~4.4.1"
             },
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/source-map": {
@@ -2395,9 +2377,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/tests/integration/specs/server-connection.spec.js
+++ b/tests/integration/specs/server-connection.spec.js
@@ -261,10 +261,13 @@ test.describe('MediaSoup Server Connection', () => {
             window.testWebSocketErrors = [];
         });
 
-        // Mock WebSocket to simulate errors more effectively
+        // Mock WebSocket to simulate errors more effectively.
+        // Must be a regular function (not an arrow) so `new WebSocket(url)` in the
+        // client code does not throw "not a constructor".
         await page.evaluate(() => {
             const OriginalWebSocket = window.WebSocket;
-            window.WebSocket = (url) => {
+            // biome-ignore lint/complexity/useArrowFunction: arrow functions cannot be invoked with `new`
+            window.WebSocket = function (url) {
                 console.log('WebSocket constructor called with URL:', url);
                 window.testWebSocketErrors.push({
                     action: 'constructor_called',

--- a/tests/integration/specs/settings-config.spec.js
+++ b/tests/integration/specs/settings-config.spec.js
@@ -149,10 +149,12 @@ test.describe('MediaSoup Settings Configuration', () => {
         expect(audioOptions.length).toBeGreaterThan(1); // Should have more than just 'Browser Default'
         expect(audioOptions).toContain('Browser Default'); // Always has this default option
 
-        // Check that we have some audio input devices beyond the default
-        const audioInputDevices = audioOptions.filter(
-            (option) => option !== 'Browser Default' && option.includes('Audio')
-        );
+        // Check that we have some audio input devices beyond the default.
+        // The sandbox only appends audioinput devices to #audio-device, so any
+        // non-default option is an audio input. We can't filter on label text:
+        // Chromium's fake-device labels contain "Audio" but Firefox's
+        // enumerateDevices returns empty labels, falling back to "audioinput <id>".
+        const audioInputDevices = audioOptions.filter((option) => option !== 'Browser Default');
         expect(audioInputDevices.length).toBeGreaterThan(0);
 
         // For video devices, check that we have at least the default option


### PR DESCRIPTION
## Summary

Work-in-progress branch for refreshing `docs/blueprint/` so it reflects the current codebase (Biome migration, Playwright suite, Rust SFU server, etc.).

First commit just gitignores `.serena/` — the Serena MCP server auto-regenerates that directory locally, but #113 removed it from the repo, so it shouldn't leak back in.

## Planned follow-ups (not yet committed)

- Update or supersede ADR-002 (ESLint → Biome, per #112)
- Add ADR for Biome lint/format tooling
- Add ADR for Playwright integration testing strategy
- Add PRD for the Rust MediaSoup SFU server component
- Refresh `feature-tracker.md` against current implementation status
- Update `manifest.md` / `manifest.yaml` to list new docs

## Test plan

- [ ] `git status` stays clean after running Serena-enabled sessions
- [ ] Blueprint docs accurately describe current tooling once content PRs land

https://claude.ai/code/session_01E7dofPvUNgELhJG8DExtCq

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7dofPvUNgELhJG8DExtCq)_