### PR TITLE
fix: critical signaling protocol + consume path, auth/TLS, CHANGELOG markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-<<<<<<< Updated upstream
 ## [0.7.20](https://github.com/laurigates/foundryvtt-mediasoup-webrtc/compare/foundryvtt-mediasoup-webrtc-v0.7.19...foundryvtt-mediasoup-webrtc-v0.7.20) (2025-07-12)
 
 
@@ -260,20 +259,6 @@
 
 * include package-lock.json for reproducible builds ([#13](https://github.com/laurigates/foundryvtt-webrtc-mediasoup/issues/13)) ([e4e0ae2](https://github.com/laurigates/foundryvtt-webrtc-mediasoup/commit/e4e0ae25ca7762145144cf333e4ff1126059eb2f))
 
-||||||| Stash base
-=======
-## Installation
-
-To install the latest version of MediaSoupVTT in FoundryVTT:
-
-1. Open FoundryVTT and go to **Game Settings → Modules**
-2. Click **Install Module**
-3. Use this manifest URL: `https://github.com/laurigates/foundryvtt-webrtc-mediasoup/releases/latest/download/module.json`
-4. Click **Install**
-
-The module will automatically download and install the latest release.
-
->>>>>>> Stashed changes
 ## [0.4.1](https://github.com/laurigates/foundryvtt-webrtc-mediasoup/compare/v0.4.0...v0.4.1) (2025-06-29)
 
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -331,6 +331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +602,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1140,11 +1156,13 @@ dependencies = [
  "dashmap",
  "futures-util",
  "mediasoup",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "slab",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-test",
  "tokio-tungstenite",
  "tracing",
@@ -1744,6 +1762,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1810,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1915,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2055,12 @@ dependencies = [
  "phf_shared",
  "precomputed-hash",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2103,6 +2191,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2330,6 +2428,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf-8"
@@ -2663,3 +2767,9 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,11 @@ mediasoup = "0.20"
 tokio-tungstenite = "0.27"
 tokio = { version = "1.35", features = ["full"] }
 
+# Optional native TLS termination (wss://). Uses the `ring` crypto provider to
+# avoid an aws-lc-rs/cmake build dependency.
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
+rustls-pemfile = "2"
+
 # HTTP server for static files
 warp = "0.4"
 

--- a/server/SECURITY_AUDIT.md
+++ b/server/SECURITY_AUDIT.md
@@ -1,5 +1,37 @@
 # Security Audit Report
 
+> **Scope note:** Most of this document covers *dependency* advisories only. The
+> application-level security posture is summarized below and should not be
+> assumed to be "hardened" beyond what is listed here (see #118).
+
+## Application Security Posture
+
+### Authentication (shared-secret gate)
+- The server requires an `authenticate` handshake as the first WebSocket frame.
+  Clients must present the shared secret configured via `MEDIASOUP_AUTH_TOKEN`
+  (compared in constant time). When the variable is unset, the server runs
+  **unauthenticated** and logs a warning at startup — do not expose it that way.
+- The authenticated peer identity is the FoundryVTT `userId` supplied by the
+  client. Because the token is provisioned as a *world* setting (readable by all
+  players), this gates outside connections but does **not** prevent one
+  authenticated player from claiming another player's `userId`. True per-user
+  validation needs a Foundry-side relay that mints signed per-user tokens; that
+  is tracked as follow-up work. Only `verify_token`/the handshake need to change
+  to adopt it.
+
+### Transport security (TLS)
+- The server supports **native TLS** (`wss://`) when `MEDIASOUP_TLS_CERT` and
+  `MEDIASOUP_TLS_KEY` point at PEM files; otherwise it serves plain `ws://` and
+  expects TLS to be terminated by a reverse proxy (nginx profile in
+  `docker-compose.yml`). One of these is required in any real deployment because
+  browsers block mixed-content `ws://` from an `https://` Foundry page.
+
+### Known gaps (not yet addressed)
+- **DoS / resource limits:** no per-IP connection cap, no per-peer
+  transport/producer/consumer limits, unbounded signaling payload sizes. Tracked
+  separately.
+- **Per-user spoofing:** see the relay note above.
+
 ## Updated Dependencies (2025-09-08)
 
 ### Major Version Updates

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -13,6 +13,13 @@ services:
       - MEDIASOUP_LOG_TAGS=info,ice,dtls,rtp,rtcp
       - MEDIASOUP_RTC_MIN_PORT=10000
       - MEDIASOUP_RTC_MAX_PORT=10100
+      # Shared secret clients must present to connect (see #118). Without it the
+      # server runs UNAUTHENTICATED. Set the same value in the module settings.
+      - MEDIASOUP_AUTH_TOKEN=${MEDIASOUP_AUTH_TOKEN:-}
+      # Optional native TLS (wss://). Point these at mounted PEM files to let the
+      # server terminate TLS itself instead of using the nginx reverse proxy.
+      # - MEDIASOUP_TLS_CERT=/app/tls/fullchain.pem
+      # - MEDIASOUP_TLS_KEY=/app/tls/privkey.pem
       # Uncomment and set for NAT/public deployment
       # - MEDIASOUP_ANNOUNCED_IP=your-public-ip
     restart: unless-stopped

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -19,6 +19,22 @@ pub struct Config {
     
     /// WebRTC transport settings
     pub webrtc: WebRtcConfig,
+
+    /// Shared secret required from clients to connect. When `None`, the server
+    /// runs unauthenticated (development only) and logs a warning. See #118.
+    pub auth_token: Option<String>,
+
+    /// Optional native TLS termination. When set, the server accepts `wss://`
+    /// directly; when `None`, it serves plain `ws://` and expects TLS to be
+    /// terminated by a reverse proxy.
+    pub tls: Option<TlsConfig>,
+}
+
+/// Paths to the PEM-encoded certificate chain and private key for native TLS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TlsConfig {
+    pub cert_path: String,
+    pub key_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,8 +131,20 @@ impl Config {
                     }
                 ],
             },
+
+            auth_token: std::env::var("MEDIASOUP_AUTH_TOKEN")
+                .ok()
+                .filter(|s| !s.is_empty()),
+
+            tls: match (
+                std::env::var("MEDIASOUP_TLS_CERT").ok().filter(|s| !s.is_empty()),
+                std::env::var("MEDIASOUP_TLS_KEY").ok().filter(|s| !s.is_empty()),
+            ) {
+                (Some(cert_path), Some(key_path)) => Some(TlsConfig { cert_path, key_path }),
+                _ => None,
+            },
         };
-        
+
         Ok(config)
     }
     

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,4 +7,4 @@ pub mod signaling;
 pub use config::Config;
 pub use error::{MediaSoupError, Result};
 pub use server::MediaSoupServer;
-pub use signaling::SignalingMessage;
+pub use signaling::{IncomingMessage, OutgoingMessage};

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -1,6 +1,6 @@
 use crate::config::ListenIp;
 use crate::error::{MediaSoupError, Result};
-use crate::signaling::{NewProducerNotification, ProducerClosedNotification, SignalingMessage};
+use crate::signaling::OutgoingMessage;
 use dashmap::DashMap;
 use mediasoup::prelude::*;
 use serde_json::Value;
@@ -10,6 +10,15 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
+/// Lowercase wire representation of a media kind ("audio" / "video"),
+/// matching the constants the FoundryVTT client compares against.
+pub fn media_kind_str(kind: MediaKind) -> &'static str {
+    match kind {
+        MediaKind::Audio => "audio",
+        MediaKind::Video => "video",
+    }
+}
+
 /// Represents a peer connection in a room
 #[derive(Debug)]
 pub struct Peer {
@@ -18,11 +27,11 @@ pub struct Peer {
     pub transports: DashMap<String, WebRtcTransport>,
     pub producers: DashMap<String, Producer>,
     pub consumers: DashMap<String, Consumer>,
-    pub message_sender: mpsc::UnboundedSender<SignalingMessage>,
+    pub message_sender: mpsc::UnboundedSender<OutgoingMessage>,
 }
 
 impl Peer {
-    pub fn new(user_id: String, message_sender: mpsc::UnboundedSender<SignalingMessage>) -> Self {
+    pub fn new(user_id: String, message_sender: mpsc::UnboundedSender<OutgoingMessage>) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             user_id,
@@ -34,7 +43,7 @@ impl Peer {
     }
     
     /// Send a message to this peer
-    pub fn send_message(&self, message: SignalingMessage) -> Result<()> {
+    pub fn send_message(&self, message: OutgoingMessage) -> Result<()> {
         self.message_sender
             .send(message)
             .map_err(|_| MediaSoupError::InvalidRequest("Peer disconnected".to_string()))?;
@@ -95,21 +104,23 @@ impl Room {
     /// Remove a peer from the room
     pub async fn remove_peer(&self, peer_id: &str) -> Result<()> {
         if let Some((_, peer)) = self.peers.remove(peer_id) {
-            // Close peer's resources
-            peer.close().await?;
-            
-            // Notify other peers about closed producers
-            for producer in peer.producers.iter() {
-                let notification = SignalingMessage::notification(
-                    "producerClosed".to_string(),
-                    Some(serde_json::to_value(ProducerClosedNotification {
-                        producer_id: producer.id().to_string(),
-                    })?),
+            // Notify other peers about this peer's producers BEFORE tearing them
+            // down. `Peer::close` clears the producer map, so collecting the ids
+            // first is required for the `producerClosed` notifications to fire at
+            // all (otherwise remaining peers' consumers hang).
+            let producer_ids: Vec<String> =
+                peer.producers.iter().map(|producer| producer.id().to_string()).collect();
+            for producer_id in producer_ids {
+                let notification = OutgoingMessage::notification(
+                    "producerClosed",
+                    serde_json::json!({ "producerId": producer_id }),
                 );
-                
                 self.broadcast_to_others(&peer.id, notification).await?;
             }
-            
+
+            // Close peer's resources
+            peer.close().await?;
+
             info!("Removed peer {} from room {}", peer_id, self.id);
         }
         
@@ -122,7 +133,7 @@ impl Room {
     }
     
     /// Broadcast a message to all peers except the sender
-    pub async fn broadcast_to_others(&self, sender_id: &str, message: SignalingMessage) -> Result<()> {
+    pub async fn broadcast_to_others(&self, sender_id: &str, message: OutgoingMessage) -> Result<()> {
         for peer in self.peers.iter() {
             if peer.id != sender_id {
                 if let Err(e) = peer.send_message(message.clone()) {
@@ -134,7 +145,7 @@ impl Room {
     }
     
     /// Broadcast a message to all peers
-    pub async fn broadcast_to_all(&self, message: SignalingMessage) -> Result<()> {
+    pub async fn broadcast_to_all(&self, message: OutgoingMessage) -> Result<()> {
         for peer in self.peers.iter() {
             if let Err(e) = peer.send_message(message.clone()) {
                 warn!("Failed to send message to peer {}: {}", peer.id, e);
@@ -225,16 +236,17 @@ impl Room {
         
         info!("Created producer {} for peer {} in room {}", producer_id, peer_id, self.id);
         
-        // Notify other peers about the new producer
-        let notification = SignalingMessage::notification(
-            "newProducer".to_string(),
-            Some(serde_json::to_value(NewProducerNotification {
-                id: producer_id,
-                user_id: peer.user_id.clone(),
-                kind: format!("{:?}", kind),
-            })?),
+        // Notify other peers about the new producer. Fields are flat and the
+        // kind is lowercased ("audio"/"video") to match the client.
+        let notification = OutgoingMessage::notification(
+            "newProducer",
+            serde_json::json!({
+                "producerId": producer_id,
+                "userId": peer.user_id.clone(),
+                "kind": media_kind_str(kind),
+            }),
         );
-        
+
         self.broadcast_to_others(&peer.id, notification).await?;
         
         Ok(producer)
@@ -271,8 +283,14 @@ impl Room {
             return Err(MediaSoupError::Consumer("Cannot consume producer".to_string()));
         }
         
+        // Create the consumer paused, as recommended by mediasoup, so the client
+        // can be ready before media flows. The client resumes it via the
+        // `consumerResume` request once the local consumer is set up.
+        let mut consumer_options = ConsumerOptions::new(producer.id(), rtp_capabilities);
+        consumer_options.paused = true;
+
         let consumer = transport
-            .consume(ConsumerOptions::new(producer.id(), rtp_capabilities))
+            .consume(consumer_options)
             .await
             .map_err(|e| MediaSoupError::Consumer(e.to_string()))?;
         
@@ -288,7 +306,7 @@ impl Room {
     pub fn get_rtp_capabilities(&self) -> RtpCapabilitiesFinalized {
         self.router.rtp_capabilities()
     }
-    
+
     /// Define media codecs for the router
     fn media_codecs() -> Vec<RtpCodecCapability> {
         vec![

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::error::{MediaSoupError, Result};
-use crate::room::{Peer, Room};
+use crate::room::{media_kind_str, Peer, Room};
 use crate::signaling::*;
 use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
@@ -64,7 +64,7 @@ impl MediaSoupServer {
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
         
         // Create a channel for sending messages to this peer
-        let (message_sender, mut message_receiver) = mpsc::unbounded_channel::<SignalingMessage>();
+        let (message_sender, mut message_receiver) = mpsc::unbounded_channel::<OutgoingMessage>();
         
         // Extract user ID from connection (for now use a UUID, in production this would come from authentication)
         let user_id = Uuid::new_v4().to_string();
@@ -149,86 +149,58 @@ impl MediaSoupServer {
         peer: &Arc<Peer>,
         room: &Arc<Room>,
     ) -> Result<()> {
-        let message: SignalingMessage = serde_json::from_str(text)?;
-        debug!("Received message: {} from peer {}", message.method, peer.id);
-        
-        let response = match message.method.as_str() {
-            "getRouterRtpCapabilities" => {
-                self.handle_get_router_rtp_capabilities(&message, room).await
-            }
+        let message: IncomingMessage = serde_json::from_str(text)?;
+        debug!("Received message: {} from peer {}", message.msg_type, peer.id);
+
+        let result: Result<Value> = match message.msg_type.as_str() {
+            "getRouterRtpCapabilities" => self.handle_get_router_rtp_capabilities(room).await,
             "createWebRtcTransport" => {
                 self.handle_create_webrtc_transport(&message, peer, room).await
             }
-            "connectTransport" => {
-                self.handle_connect_transport(&message, peer).await
-            }
-            "produce" => {
-                self.handle_produce(&message, peer, room).await
-            }
-            "consume" => {
-                self.handle_consume(&message, peer, room).await
-            }
-            "pauseProducer" => {
-                self.handle_pause_producer(&message, peer).await
-            }
-            "resumeProducer" => {
-                self.handle_resume_producer(&message, peer).await
-            }
-            _ => {
-                warn!("Unknown method: {}", message.method);
-                Ok(message.to_response(None, Some(format!("Unknown method: {}", message.method))))
-            }
+            "connectTransport" => self.handle_connect_transport(&message, peer).await,
+            "produce" => self.handle_produce(&message, peer, room).await,
+            "consume" => self.handle_consume(&message, peer, room).await,
+            "consumerResume" => self.handle_resume_consumer(&message, peer).await,
+            "pauseProducer" => self.handle_pause_producer(&message, peer).await,
+            "resumeProducer" => self.handle_resume_producer(&message, peer).await,
+            other => Err(MediaSoupError::InvalidRequest(format!("Unknown method: {other}"))),
         };
-        
-        // Send response if this was a request
-        if message.is_request() {
-            let response = response?;
-            peer.send_message(SignalingMessage {
-                id: Some(response.id),
-                method: "response".to_string(),
-                data: if let Some(error) = response.error {
-                    Some(serde_json::json!({ "error": error }))
-                } else {
-                    response.response
-                },
-            })?;
+
+        // Reply only if the client correlated this with a requestId.
+        if let Some(request_id) = message.request_id.clone() {
+            let outgoing = match result {
+                Ok(data) => OutgoingMessage::response(request_id, data),
+                Err(e) => {
+                    warn!("Request '{}' failed: {}", message.msg_type, e);
+                    OutgoingMessage::error(request_id, e.to_string())
+                }
+            };
+            peer.send_message(outgoing)?;
+        } else if let Err(e) = result {
+            error!("Error handling '{}' (no requestId): {}", message.msg_type, e);
         }
-        
+
         Ok(())
     }
-    
+
     /// Handle getRouterRtpCapabilities request
-    async fn handle_get_router_rtp_capabilities(
-        &self,
-        message: &SignalingMessage,
-        room: &Arc<Room>,
-    ) -> Result<SignalingResponse> {
+    async fn handle_get_router_rtp_capabilities(&self, room: &Arc<Room>) -> Result<Value> {
         let capabilities = room.get_rtp_capabilities();
-        let response_data = serde_json::to_value(capabilities)?;
-        
-        Ok(message.to_response(Some(response_data), None))
+        Ok(serde_json::to_value(capabilities)?)
     }
-    
+
     /// Handle createWebRtcTransport request
     async fn handle_create_webrtc_transport(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
         room: &Arc<Room>,
-    ) -> Result<SignalingResponse> {
-        let data: CreateWebRtcTransportData = if let Some(data) = &message.data {
-            serde_json::from_value(data.clone())?
-        } else {
-            CreateWebRtcTransportData {
-                producing: None,
-                consuming: None,
-                sctp_capabilities: None,
-            }
-        };
-        
+    ) -> Result<Value> {
+        let data: CreateWebRtcTransportData = serde_json::from_value(message.payload_value())?;
+
         // Use config listen IPs directly
         let listen_ips = self.config.webrtc.listen_ips.clone();
-        
+
         let transport = room.create_webrtc_transport(
             &peer.id,
             listen_ips,
@@ -237,58 +209,57 @@ impl MediaSoupServer {
             true,  // prefer_udp
             data.sctp_capabilities.is_some(), // enable_sctp
         ).await?;
-        
-        let response_data = serde_json::to_value(TransportCreatedResponse {
+
+        Ok(serde_json::to_value(TransportCreatedResponse {
             id: transport.id().to_string(),
             ice_parameters: serde_json::to_value(transport.ice_parameters())?,
             ice_candidates: serde_json::to_value(transport.ice_candidates())?,
             dtls_parameters: serde_json::to_value(transport.dtls_parameters())?,
-            sctp_parameters: transport.sctp_parameters().map(|p| serde_json::to_value(p)).transpose()?,
-        })?;
-        
-        Ok(message.to_response(Some(response_data), None))
+            sctp_parameters: transport.sctp_parameters().map(serde_json::to_value).transpose()?,
+        })?)
     }
-    
+
     /// Handle connectTransport request
     async fn handle_connect_transport(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
-    ) -> Result<SignalingResponse> {
-        let data: ConnectTransportData = serde_json::from_value(
-            message.data.clone().ok_or_else(|| MediaSoupError::InvalidRequest("Missing data".to_string()))?
-        )?;
-        
-        let transport = peer.transports.get(&data.transport_id)
+    ) -> Result<Value> {
+        let data: ConnectTransportData = serde_json::from_value(message.payload_value())?;
+
+        // Clone the (Arc-backed) transport handle and drop the DashMap guard
+        // before awaiting, so we never hold a shard lock across `.await`.
+        let transport = peer
+            .transports
+            .get(&data.transport_id)
+            .map(|t| t.clone())
             .ok_or_else(|| MediaSoupError::TransportNotFound(data.transport_id.clone()))?;
-        
+
         let dtls_parameters: DtlsParameters = serde_json::from_value(data.dtls_parameters)?;
-        
+
         transport.connect(WebRtcTransportRemoteParameters { dtls_parameters }).await
             .map_err(|e| MediaSoupError::Transport(e.to_string()))?;
-        
-        Ok(message.to_response(Some(serde_json::json!({})), None))
+
+        Ok(serde_json::json!({}))
     }
-    
+
     /// Handle produce request
     async fn handle_produce(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
         room: &Arc<Room>,
-    ) -> Result<SignalingResponse> {
-        let data: ProduceData = serde_json::from_value(
-            message.data.clone().ok_or_else(|| MediaSoupError::InvalidRequest("Missing data".to_string()))?
-        )?;
-        
+    ) -> Result<Value> {
+        let data: ProduceData = serde_json::from_value(message.payload_value())?;
+
         let kind = match data.kind.as_str() {
             "audio" => MediaKind::Audio,
             "video" => MediaKind::Video,
-            _ => return Err(MediaSoupError::InvalidRequest(format!("Invalid media kind: {}", data.kind))),
+            other => return Err(MediaSoupError::InvalidRequest(format!("Invalid media kind: {other}"))),
         };
-        
+
         let rtp_parameters: RtpParameters = serde_json::from_value(data.rtp_parameters)?;
-        
+
         let producer = room.create_producer(
             &peer.id,
             &data.transport_id,
@@ -296,82 +267,97 @@ impl MediaSoupServer {
             rtp_parameters,
             data.app_data,
         ).await?;
-        
-        let response_data = serde_json::to_value(ProducedResponse {
+
+        Ok(serde_json::to_value(ProducedResponse {
             id: producer.id().to_string(),
-        })?;
-        
-        Ok(message.to_response(Some(response_data), None))
+        })?)
     }
-    
+
     /// Handle consume request
     async fn handle_consume(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
         room: &Arc<Room>,
-    ) -> Result<SignalingResponse> {
-        let data: ConsumeData = serde_json::from_value(
-            message.data.clone().ok_or_else(|| MediaSoupError::InvalidRequest("Missing data".to_string()))?
-        )?;
-        
+    ) -> Result<Value> {
+        let data: ConsumeData = serde_json::from_value(message.payload_value())?;
+
         let rtp_capabilities: RtpCapabilities = serde_json::from_value(data.rtp_capabilities)?;
-        
+
         let consumer = room.create_consumer(
             &peer.id,
             &data.transport_id,
             &data.producer_id,
             rtp_capabilities,
         ).await?;
-        
-        let response_data = serde_json::to_value(ConsumedResponse {
+
+        Ok(serde_json::to_value(ConsumedResponse {
             id: consumer.id().to_string(),
             producer_id: data.producer_id,
-            kind: format!("{:?}", consumer.kind()),
+            kind: media_kind_str(consumer.kind()).to_string(),
             rtp_parameters: serde_json::to_value(consumer.rtp_parameters())?,
-        })?;
-        
-        Ok(message.to_response(Some(response_data), None))
+            producer_paused: consumer.producer_paused(),
+        })?)
     }
-    
+
+    /// Handle consumerResume request (resume a consumer created paused)
+    async fn handle_resume_consumer(
+        &self,
+        message: &IncomingMessage,
+        peer: &Arc<Peer>,
+    ) -> Result<Value> {
+        let consumer_id = message.payload.get("consumerId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| MediaSoupError::InvalidRequest("Missing consumerId".to_string()))?;
+
+        let consumer = peer.consumers.get(consumer_id)
+            .map(|c| c.clone())
+            .ok_or_else(|| MediaSoupError::ConsumerNotFound(consumer_id.to_string()))?;
+
+        consumer.resume().await
+            .map_err(|e| MediaSoupError::Consumer(e.to_string()))?;
+
+        Ok(serde_json::json!({}))
+    }
+
     /// Handle pauseProducer request
     async fn handle_pause_producer(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
-    ) -> Result<SignalingResponse> {
-        let data: Value = message.data.clone().ok_or_else(|| MediaSoupError::InvalidRequest("Missing data".to_string()))?;
-        let producer_id = data.get("producerId")
+    ) -> Result<Value> {
+        let producer_id = message.payload.get("producerId")
             .and_then(|v| v.as_str())
             .ok_or_else(|| MediaSoupError::InvalidRequest("Missing producerId".to_string()))?;
-        
+
         let producer = peer.producers.get(producer_id)
+            .map(|p| p.clone())
             .ok_or_else(|| MediaSoupError::ProducerNotFound(producer_id.to_string()))?;
-        
+
         producer.pause().await
             .map_err(|e| MediaSoupError::Producer(e.to_string()))?;
-        
-        Ok(message.to_response(Some(serde_json::json!({})), None))
+
+        Ok(serde_json::json!({}))
     }
-    
+
     /// Handle resumeProducer request
     async fn handle_resume_producer(
         &self,
-        message: &SignalingMessage,
+        message: &IncomingMessage,
         peer: &Arc<Peer>,
-    ) -> Result<SignalingResponse> {
-        let data: Value = message.data.clone().ok_or_else(|| MediaSoupError::InvalidRequest("Missing data".to_string()))?;
-        let producer_id = data.get("producerId")
+    ) -> Result<Value> {
+        let producer_id = message.payload.get("producerId")
             .and_then(|v| v.as_str())
             .ok_or_else(|| MediaSoupError::InvalidRequest("Missing producerId".to_string()))?;
-        
+
         let producer = peer.producers.get(producer_id)
+            .map(|p| p.clone())
             .ok_or_else(|| MediaSoupError::ProducerNotFound(producer_id.to_string()))?;
-        
+
         producer.resume().await
             .map_err(|e| MediaSoupError::Producer(e.to_string()))?;
-        
-        Ok(message.to_response(Some(serde_json::json!({})), None))
+
+        Ok(serde_json::json!({}))
     }
     
     /// Get or create a room

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,8 +1,9 @@
-use crate::config::Config;
+use crate::config::{Config, TlsConfig};
 use crate::error::{MediaSoupError, Result};
 use crate::room::{media_kind_str, Peer, Room};
 use crate::signaling::*;
 use dashmap::DashMap;
+use futures_util::stream::SplitStream;
 use futures_util::{SinkExt, StreamExt};
 use mediasoup::prelude::*;
 use mediasoup::worker_manager::WorkerManager;
@@ -10,11 +11,83 @@ use mediasoup::worker::WorkerSettings;
 use serde_json::Value;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpListener;
 use tokio::sync::mpsc;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::ServerConfig as RustlsServerConfig;
+use tokio_rustls::TlsAcceptor;
 use tokio_tungstenite::{accept_async, tungstenite::Message, WebSocketStream};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+/// A stream usable as the transport under a WebSocket connection (plain TCP or
+/// a TLS-wrapped TCP stream).
+trait IoStream: AsyncRead + AsyncWrite + Unpin + Send + 'static {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> IoStream for T {}
+
+/// Serialize and send a single signaling frame directly over a WebSocket sink
+/// (used during the pre-peer authentication handshake).
+async fn send_frame(
+    ws_sender: &mut (impl SinkExt<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin),
+    message: OutgoingMessage,
+) -> Result<()> {
+    let json = serde_json::to_string(&message)?;
+    ws_sender
+        .send(Message::Text(json.into()))
+        .await
+        .map_err(MediaSoupError::from)
+}
+
+/// Length-checked, constant-time byte comparison (avoids early-exit timing
+/// leaks on the shared secret).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Load a rustls `TlsAcceptor` from PEM certificate-chain and private-key files.
+fn load_tls_acceptor(tls: &TlsConfig) -> Result<TlsAcceptor> {
+    let cert_bytes = std::fs::read(&tls.cert_path).map_err(|e| {
+        MediaSoupError::Config(format!("Failed to read TLS cert {}: {}", tls.cert_path, e))
+    })?;
+    let key_bytes = std::fs::read(&tls.key_path).map_err(|e| {
+        MediaSoupError::Config(format!("Failed to read TLS key {}: {}", tls.key_path, e))
+    })?;
+
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_bytes.as_slice())
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| MediaSoupError::Config(format!("Invalid TLS certificate: {e}")))?;
+    if certs.is_empty() {
+        return Err(MediaSoupError::Config(format!(
+            "No certificates found in {}",
+            tls.cert_path
+        )));
+    }
+
+    let key: PrivateKeyDer<'static> = rustls_pemfile::private_key(&mut key_bytes.as_slice())
+        .map_err(|e| MediaSoupError::Config(format!("Invalid TLS private key: {e}")))?
+        .ok_or_else(|| {
+            MediaSoupError::Config(format!("No private key found in {}", tls.key_path))
+        })?;
+
+    let server_config = RustlsServerConfig::builder_with_provider(Arc::new(
+        tokio_rustls::rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| MediaSoupError::Config(format!("Failed to select TLS protocol versions: {e}")))?
+    .with_no_client_auth()
+    .with_single_cert(certs, key)
+    .map_err(|e| MediaSoupError::Config(format!("Failed to build TLS config: {e}")))?;
+
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
 
 /// Main MediaSoup server
 pub struct MediaSoupServer {
@@ -39,47 +112,87 @@ impl MediaSoupServer {
     pub async fn run(self) -> Result<()> {
         let listener = TcpListener::bind(&self.config.listen_addr).await
             .map_err(|e| MediaSoupError::Config(format!("Failed to bind to {}: {}", self.config.listen_addr, e)))?;
-        
+
+        // Build an optional TLS acceptor for native wss:// termination.
+        let tls_acceptor = match &self.config.tls {
+            Some(tls) => {
+                let acceptor = load_tls_acceptor(tls)?;
+                info!("Native TLS enabled (wss://) using cert {}", tls.cert_path);
+                Some(acceptor)
+            }
+            None => {
+                info!("Native TLS disabled; serving ws:// (terminate TLS at a reverse proxy for browsers)");
+                None
+            }
+        };
+
+        if self.config.auth_token.is_none() {
+            warn!(
+                "MEDIASOUP_AUTH_TOKEN is not set: the server is UNAUTHENTICATED. \
+                 Set a shared secret before exposing it to a network."
+            );
+        }
+
         info!("WebSocket server listening on {}", self.config.listen_addr);
-        
+
         let server = Arc::new(self);
-        
+
         while let Ok((stream, addr)) = listener.accept().await {
             let server_clone = server.clone();
+            let acceptor = tls_acceptor.clone();
             tokio::spawn(async move {
-                if let Err(e) = server_clone.handle_connection(stream, addr).await {
+                let result = match acceptor {
+                    Some(acceptor) => match acceptor.accept(stream).await {
+                        Ok(tls_stream) => server_clone.handle_connection(tls_stream, addr).await,
+                        Err(e) => {
+                            error!("TLS handshake failed from {}: {}", addr, e);
+                            return;
+                        }
+                    },
+                    None => server_clone.handle_connection(stream, addr).await,
+                };
+                if let Err(e) = result {
                     error!("Error handling connection from {}: {}", addr, e);
                 }
             });
         }
-        
+
         Ok(())
     }
-    
-    /// Handle a new WebSocket connection
-    async fn handle_connection(&self, stream: TcpStream, addr: SocketAddr) -> Result<()> {
+
+    /// Handle a new WebSocket connection (over plain TCP or TLS).
+    async fn handle_connection<S: IoStream>(&self, stream: S, addr: SocketAddr) -> Result<()> {
         info!("New connection from {}", addr);
-        
+
         let ws_stream = accept_async(stream).await?;
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
-        
+
+        // Authenticate before allocating any room/peer resources. On failure we
+        // reply with an error and drop the connection (see #118).
+        let user_id = match self.authenticate(&mut ws_receiver, &mut ws_sender).await {
+            Ok(user_id) => user_id,
+            Err(e) => {
+                warn!("Authentication failed for {}: {}", addr, e);
+                return Err(e);
+            }
+        };
+
         // Create a channel for sending messages to this peer
         let (message_sender, mut message_receiver) = mpsc::unbounded_channel::<OutgoingMessage>();
-        
-        // Extract user ID from connection (for now use a UUID, in production this would come from authentication)
-        let user_id = Uuid::new_v4().to_string();
+
+        // Identity is the authenticated FoundryVTT user id.
         let peer = Arc::new(Peer::new(user_id, message_sender));
-        
+
         // Get or create a default room (in production, this would be based on authentication/routing)
         let room_id = "default".to_string();
         let room = self.get_or_create_room(&room_id).await?;
-        
+
         // Add peer to room
         room.add_peer(peer.clone()).await?;
-        
+
         let peer_id = peer.id.clone();
         let room_clone = room.clone();
-        
+
         // Spawn task to handle outgoing messages
         let outgoing_task = {
             tokio::spawn(async move {
@@ -91,7 +204,7 @@ impl MediaSoupServer {
                             continue;
                         }
                     };
-                    
+
                     if let Err(e) = ws_sender.send(Message::Text(json.into())).await {
                         error!("Failed to send message: {}", e);
                         break;
@@ -99,24 +212,104 @@ impl MediaSoupServer {
                 }
             })
         };
-        
+
         // Handle incoming messages
         let incoming_result = self.handle_incoming_messages(&mut ws_receiver, peer.clone(), room.clone()).await;
-        
+
         // Cleanup
         outgoing_task.abort();
         if let Err(e) = room_clone.remove_peer(&peer_id).await {
             error!("Failed to remove peer {}: {}", peer_id, e);
         }
-        
+
         info!("Connection from {} closed", addr);
         incoming_result
     }
-    
-    /// Handle incoming WebSocket messages
-    async fn handle_incoming_messages(
+
+    /// Perform the authentication handshake. The client's first frame must be an
+    /// `authenticate` request carrying the shared `token` (when one is
+    /// configured) and `userId`. Returns the authenticated user id.
+    ///
+    /// This is a deployment-level shared-secret gate (#118). True per-user
+    /// FoundryVTT session validation needs a Foundry-side relay to mint signed
+    /// per-user tokens; that is tracked as a follow-up. Once such a relay exists,
+    /// only `verify_token` below needs to change.
+    async fn authenticate<S: IoStream>(
         &self,
-        ws_receiver: &mut futures_util::stream::SplitStream<WebSocketStream<TcpStream>>,
+        ws_receiver: &mut SplitStream<WebSocketStream<S>>,
+        ws_sender: &mut (impl SinkExt<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin),
+    ) -> Result<String> {
+        while let Some(frame) = ws_receiver.next().await {
+            let frame = frame?;
+            let text = match frame {
+                Message::Text(text) => text,
+                Message::Close(_) => {
+                    return Err(MediaSoupError::InvalidRequest("Closed before auth".to_string()))
+                }
+                _ => continue, // ignore pings/binary before auth
+            };
+
+            let message: IncomingMessage = serde_json::from_str(&text)?;
+            if message.msg_type != "authenticate" {
+                let err = "Authentication required: first message must be 'authenticate'";
+                if let Some(request_id) = message.request_id.clone() {
+                    send_frame(ws_sender, OutgoingMessage::error(request_id, err.to_string())).await?;
+                }
+                return Err(MediaSoupError::InvalidRequest(err.to_string()));
+            }
+
+            let provided = message
+                .payload
+                .get("token")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            if let Err(e) = self.verify_token(provided) {
+                if let Some(request_id) = message.request_id.clone() {
+                    send_frame(ws_sender, OutgoingMessage::error(request_id, e.to_string())).await?;
+                }
+                return Err(e);
+            }
+
+            // Identity is the client-supplied FoundryVTT user id; fall back to a
+            // random id if absent so peers remain distinguishable.
+            let user_id = message
+                .user_id
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+            if let Some(request_id) = message.request_id.clone() {
+                send_frame(ws_sender, OutgoingMessage::response(request_id, serde_json::json!({})))
+                    .await?;
+            }
+
+            debug!("Authenticated user {}", user_id);
+            return Ok(user_id);
+        }
+
+        Err(MediaSoupError::InvalidRequest("Connection closed before authentication".to_string()))
+    }
+
+    /// Validate a client-provided token against the configured shared secret
+    /// using a length-checked, constant-time comparison.
+    fn verify_token(&self, provided: &str) -> Result<()> {
+        match &self.config.auth_token {
+            None => Ok(()), // unauthenticated mode (warned at startup)
+            Some(expected) => {
+                if constant_time_eq(expected.as_bytes(), provided.as_bytes()) {
+                    Ok(())
+                } else {
+                    Err(MediaSoupError::InvalidRequest("Invalid authentication token".to_string()))
+                }
+            }
+        }
+    }
+
+    /// Handle incoming WebSocket messages
+    async fn handle_incoming_messages<S: IoStream>(
+        &self,
+        ws_receiver: &mut SplitStream<WebSocketStream<S>>,
         peer: Arc<Peer>,
         room: Arc<Room>,
     ) -> Result<()> {
@@ -153,6 +346,9 @@ impl MediaSoupServer {
         debug!("Received message: {} from peer {}", message.msg_type, peer.id);
 
         let result: Result<Value> = match message.msg_type.as_str() {
+            // Authentication already happened during the handshake; a stray
+            // re-auth is a harmless no-op.
+            "authenticate" => Ok(serde_json::json!({})),
             "getRouterRtpCapabilities" => self.handle_get_router_rtp_capabilities(room).await,
             "createWebRtcTransport" => {
                 self.handle_create_webrtc_transport(&message, peer, room).await
@@ -440,4 +636,21 @@ impl CustomWorkerManager {
         }
     }
     */
+}
+#[cfg(test)]
+mod tests {
+    use super::constant_time_eq;
+
+    #[test]
+    fn constant_time_eq_matches_identical_secrets() {
+        assert!(constant_time_eq(b"s3cret-token", b"s3cret-token"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_mismatches_and_length_differences() {
+        assert!(!constant_time_eq(b"s3cret-token", b"wrong-token!"));
+        assert!(!constant_time_eq(b"short", b"longer-secret"));
+        assert!(!constant_time_eq(b"token", b""));
+    }
 }

--- a/server/src/signaling.rs
+++ b/server/src/signaling.rs
@@ -1,202 +1,190 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use uuid::Uuid;
+use serde_json::{Map, Value};
 
-/// WebSocket signaling message for communication between client and server
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalingMessage {
-    pub id: Option<String>,
-    pub method: String,
-    pub data: Option<Value>,
+/// Incoming signaling frame from the FoundryVTT client.
+///
+/// The client uses a flat envelope:
+/// `{ "type", "requestId", "userId", <payload fields...> }`
+/// (see `src/client/MediaSoupVTTClient.js` `_sendSignalingRequest`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct IncomingMessage {
+    /// Operation name, e.g. `produce`, `consume`, `getRouterRtpCapabilities`.
+    #[serde(rename = "type")]
+    pub msg_type: String,
+
+    /// Correlation id, present on requests that expect a response.
+    #[serde(rename = "requestId", default)]
+    pub request_id: Option<String>,
+
+    /// Client-supplied user id (informational; authentication is out of scope).
+    #[serde(rename = "userId", default)]
+    pub user_id: Option<String>,
+
+    /// All remaining top-level fields (transportId, kind, rtpParameters, ...).
+    #[serde(flatten)]
+    pub payload: Map<String, Value>,
 }
 
-/// Request message from client
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalingRequest {
-    pub id: String,
-    pub method: String,
-    pub data: Option<Value>,
+impl IncomingMessage {
+    /// Return the payload fields as a JSON object value for typed deserialization.
+    pub fn payload_value(&self) -> Value {
+        Value::Object(self.payload.clone())
+    }
 }
 
-/// Response message to client
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalingResponse {
-    pub id: String,
-    pub response: Option<Value>,
+/// Outgoing signaling frame to the client.
+///
+/// Responses use `{ "requestId", "data"? , "error"? }`; notifications use
+/// `{ "type", <flat fields...> }`. These shapes match what the client parses in
+/// `_handleSignalingMessage` (correlates on top-level `requestId`, reads
+/// top-level `error`, resolves with `message.data`, and switches notifications
+/// on top-level `type`).
+#[derive(Debug, Clone, Serialize)]
+pub struct OutgoingMessage {
+    #[serde(rename = "requestId", skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub msg_type: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-}
 
-/// Notification message to client (no response expected)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalingNotification {
-    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+
+    /// Flattened notification fields (producerId, userId, kind, ...).
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }
 
-/// Known signaling methods matching the FoundryVTT client
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SignalingMethod {
-    #[serde(rename = "getRouterRtpCapabilities")]
-    GetRouterRtpCapabilities,
-    
-    #[serde(rename = "createWebRtcTransport")]
-    CreateWebRtcTransport,
-    
-    #[serde(rename = "connectTransport")]
-    ConnectTransport,
-    
-    #[serde(rename = "produce")]
-    Produce,
-    
-    #[serde(rename = "consume")]
-    Consume,
-    
-    #[serde(rename = "pauseProducer")]
-    PauseProducer,
-    
-    #[serde(rename = "resumeProducer")]
-    ResumeProducer,
+impl OutgoingMessage {
+    /// Successful response to a request.
+    pub fn response(request_id: String, data: Value) -> Self {
+        Self {
+            request_id: Some(request_id),
+            msg_type: None,
+            error: None,
+            data: Some(data),
+            extra: Map::new(),
+        }
+    }
+
+    /// Error response to a request.
+    pub fn error(request_id: String, error: String) -> Self {
+        Self {
+            request_id: Some(request_id),
+            msg_type: None,
+            error: Some(error),
+            data: None,
+            extra: Map::new(),
+        }
+    }
+
+    /// Server-initiated notification (no response expected). `fields` should be a
+    /// JSON object whose entries become top-level fields on the wire.
+    pub fn notification(msg_type: &str, fields: Value) -> Self {
+        let extra = match fields {
+            Value::Object(map) => map,
+            _ => Map::new(),
+        };
+        Self {
+            request_id: None,
+            msg_type: Some(msg_type.to_string()),
+            error: None,
+            data: None,
+            extra,
+        }
+    }
 }
 
-/// Transport connection data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Transport connection data (`connectTransport`).
+#[derive(Debug, Clone, Deserialize)]
 pub struct ConnectTransportData {
     #[serde(rename = "transportId")]
     pub transport_id: String,
-    
+
     #[serde(rename = "dtlsParameters")]
     pub dtls_parameters: Value,
 }
 
-/// Producer creation data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Producer creation data (`produce`).
+#[derive(Debug, Clone, Deserialize)]
 pub struct ProduceData {
     #[serde(rename = "transportId")]
     pub transport_id: String,
-    
+
     pub kind: String, // "audio" or "video"
-    
+
     #[serde(rename = "rtpParameters")]
     pub rtp_parameters: Value,
-    
-    #[serde(rename = "appData")]
+
+    #[serde(rename = "appData", default)]
     pub app_data: Option<Value>,
 }
 
-/// Consumer creation data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Consumer creation data (`consume`).
+#[derive(Debug, Clone, Deserialize)]
 pub struct ConsumeData {
     #[serde(rename = "transportId")]
     pub transport_id: String,
-    
+
     #[serde(rename = "producerId")]
     pub producer_id: String,
-    
+
     #[serde(rename = "rtpCapabilities")]
     pub rtp_capabilities: Value,
 }
 
-/// WebRTC transport creation data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// WebRTC transport creation data (`createWebRtcTransport`).
+#[derive(Debug, Clone, Deserialize)]
 pub struct CreateWebRtcTransportData {
     pub producing: Option<bool>,
     pub consuming: Option<bool>,
-    
-    #[serde(rename = "sctpCapabilities")]
+
+    #[serde(rename = "sctpCapabilities", default)]
     pub sctp_capabilities: Option<Value>,
 }
 
-/// Transport creation response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Transport creation response.
+#[derive(Debug, Clone, Serialize)]
 pub struct TransportCreatedResponse {
     pub id: String,
-    
+
     #[serde(rename = "iceParameters")]
     pub ice_parameters: Value,
-    
+
     #[serde(rename = "iceCandidates")]
     pub ice_candidates: Value,
-    
+
     #[serde(rename = "dtlsParameters")]
     pub dtls_parameters: Value,
-    
-    #[serde(rename = "sctpParameters")]
+
+    #[serde(rename = "sctpParameters", skip_serializing_if = "Option::is_none")]
     pub sctp_parameters: Option<Value>,
 }
 
-/// Producer creation response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Producer creation response.
+#[derive(Debug, Clone, Serialize)]
 pub struct ProducedResponse {
     pub id: String,
 }
 
-/// Consumer creation response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Consumer creation response.
+#[derive(Debug, Clone, Serialize)]
 pub struct ConsumedResponse {
     pub id: String,
-    
+
     #[serde(rename = "producerId")]
     pub producer_id: String,
-    
+
     pub kind: String,
-    
+
     #[serde(rename = "rtpParameters")]
     pub rtp_parameters: Value,
-}
 
-/// New producer notification
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NewProducerNotification {
-    pub id: String,
-    
-    #[serde(rename = "userId")]
-    pub user_id: String,
-    
-    pub kind: String,
-}
-
-/// Producer closed notification
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProducerClosedNotification {
-    #[serde(rename = "producerId")]
-    pub producer_id: String,
-}
-
-impl SignalingMessage {
-    /// Create a new request message
-    pub fn request(method: String, data: Option<Value>) -> Self {
-        Self {
-            id: Some(Uuid::new_v4().to_string()),
-            method,
-            data,
-        }
-    }
-    
-    /// Create a new notification message
-    pub fn notification(method: String, data: Option<Value>) -> Self {
-        Self {
-            id: None,
-            method,
-            data,
-        }
-    }
-    
-    /// Convert to response
-    pub fn to_response(&self, response: Option<Value>, error: Option<String>) -> SignalingResponse {
-        SignalingResponse {
-            id: self.id.clone().unwrap_or_default(),
-            response,
-            error,
-        }
-    }
-    
-    /// Check if this is a request (has ID)
-    pub fn is_request(&self) -> bool {
-        self.id.is_some()
-    }
-    
-    /// Check if this is a notification (no ID)
-    pub fn is_notification(&self) -> bool {
-        self.id.is_none()
-    }
+    /// Whether the underlying producer is currently paused. The client mirrors
+    /// this onto the consumer after resuming it.
+    #[serde(rename = "producerPaused")]
+    pub producer_paused: bool,
 }

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -23,6 +23,8 @@ async fn test_server_startup() {
                 announced_ip: None,
             }],
         },
+        auth_token: None,
+        tls: None,
     };
 
     // Test that server can be created

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -1,8 +1,5 @@
-use mediasoup_server::{Config, MediaSoupServer, SignalingMessage};
+use mediasoup_server::{Config, IncomingMessage, MediaSoupServer, OutgoingMessage};
 use serde_json::json;
-use std::time::Duration;
-use tokio::time::timeout;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 #[tokio::test]
 async fn test_server_startup() {
@@ -27,44 +24,78 @@ async fn test_server_startup() {
             }],
         },
     };
-    
+
     // Test that server can be created
     let server = MediaSoupServer::new(config).await;
     assert!(server.is_ok(), "Failed to create MediaSoup server");
 }
 
 #[tokio::test]
-async fn test_signaling_message_serialization() {
-    let message = SignalingMessage::request(
-        "getRouterRtpCapabilities".to_string(),
-        Some(json!({})),
-    );
-    
-    // Test serialization
-    let serialized = serde_json::to_string(&message);
-    assert!(serialized.is_ok(), "Failed to serialize signaling message");
-    
-    // Test deserialization
-    let deserialized: Result<SignalingMessage, _> = serde_json::from_str(&serialized.unwrap());
-    assert!(deserialized.is_ok(), "Failed to deserialize signaling message");
-    
-    let deserialized = deserialized.unwrap();
-    assert_eq!(deserialized.method, "getRouterRtpCapabilities");
-    assert!(deserialized.is_request());
+async fn test_incoming_message_deserialization() {
+    // The client sends a flat envelope: { type, requestId, userId, <payload...> }.
+    let raw = r#"{
+        "type": "produce",
+        "requestId": "req_3",
+        "userId": "user-1",
+        "transportId": "transport-7",
+        "kind": "audio"
+    }"#;
+
+    let message: IncomingMessage =
+        serde_json::from_str(raw).expect("Failed to deserialize incoming message");
+
+    assert_eq!(message.msg_type, "produce");
+    assert_eq!(message.request_id.as_deref(), Some("req_3"));
+    assert_eq!(message.user_id.as_deref(), Some("user-1"));
+
+    // Remaining top-level fields are captured in the flattened payload.
+    let payload = message.payload_value();
+    assert_eq!(payload["transportId"], "transport-7");
+    assert_eq!(payload["kind"], "audio");
+    // The envelope fields are not duplicated into the payload.
+    assert!(payload.get("type").is_none());
+    assert!(payload.get("requestId").is_none());
 }
 
 #[tokio::test]
-async fn test_signaling_notification() {
-    let notification = SignalingMessage::notification(
-        "newProducer".to_string(),
-        Some(json!({
-            "id": "producer-123",
+async fn test_outgoing_response_serialization() {
+    // A successful response carries the correlating requestId and a data payload.
+    let response = OutgoingMessage::response("req_3".to_string(), json!({ "id": "producer-123" }));
+    let value = serde_json::to_value(&response).expect("Failed to serialize response");
+
+    assert_eq!(value["requestId"], "req_3");
+    assert_eq!(value["data"]["id"], "producer-123");
+    // No notification or error fields leak into a response.
+    assert!(value.get("type").is_none());
+    assert!(value.get("error").is_none());
+
+    // An error response carries the error string instead of data.
+    let error = OutgoingMessage::error("req_4".to_string(), "boom".to_string());
+    let error_value = serde_json::to_value(&error).expect("Failed to serialize error");
+    assert_eq!(error_value["requestId"], "req_4");
+    assert_eq!(error_value["error"], "boom");
+    assert!(error_value.get("data").is_none());
+}
+
+#[tokio::test]
+async fn test_outgoing_notification_serialization() {
+    // Notifications use a top-level `type` plus flat fields the client reads
+    // directly (producerId, userId, kind).
+    let notification = OutgoingMessage::notification(
+        "newProducer",
+        json!({
+            "producerId": "producer-123",
             "userId": "user-456",
             "kind": "video"
-        })),
+        }),
     );
-    
-    assert!(notification.is_notification());
-    assert!(!notification.is_request());
-    assert_eq!(notification.method, "newProducer");
+
+    let value = serde_json::to_value(&notification).expect("Failed to serialize notification");
+
+    assert_eq!(value["type"], "newProducer");
+    assert_eq!(value["producerId"], "producer-123");
+    assert_eq!(value["userId"], "user-456");
+    assert_eq!(value["kind"], "video");
+    // A notification has no requestId (it does not expect a response).
+    assert!(value.get("requestId").is_none());
 }

--- a/src/client/MediaSoupVTTClient.js
+++ b/src/client/MediaSoupVTTClient.js
@@ -12,6 +12,7 @@ import {
     MODULE_TITLE,
     SETTING_DEFAULT_AUDIO_DEVICE,
     SETTING_DEFAULT_VIDEO_DEVICE,
+    SETTING_MEDIASOUP_AUTH_TOKEN,
     SETTING_MEDIASOUP_URL,
     SIG_MSG_TYPES,
     SIGNALING_REQUEST_TIMEOUT_MS,
@@ -266,6 +267,23 @@ export class MediaSoupVTTClient {
         try {
             log('Initializing mediasoup-client Device...');
             this.device = new window.mediasoupClient.Device();
+
+            // Authenticate first. The server requires this as the opening frame
+            // and gates all other signaling behind it (see #118). The token is a
+            // shared secret configured by the GM; userId is attached automatically
+            // by _sendSignalingRequest.
+            let authToken = '';
+            try {
+                authToken = game?.settings?.get(MODULE_ID, SETTING_MEDIASOUP_AUTH_TOKEN) || '';
+            } catch (settingError) {
+                log(`Could not read auth token setting: ${settingError.message}`, 'warn');
+            }
+            await this._sendSignalingRequest({
+                type: SIG_MSG_TYPES.AUTHENTICATE,
+                token: authToken,
+            });
+            log('Authenticated with MediaSoup server.', 'debug');
+
             const routerRtpCapabilities = await this._sendSignalingRequest({
                 type: SIG_MSG_TYPES.GET_ROUTER_RTP_CAPABILITIES,
             });

--- a/src/client/MediaSoupVTTClient.js
+++ b/src/client/MediaSoupVTTClient.js
@@ -829,25 +829,8 @@ export class MediaSoupVTTClient {
             return;
         }
 
-        if (!appData || !appData.rtpParameters) {
-            const errorMsg = `Cannot consume producer ${producerId}: Missing rtpParameters in appData from server notification.`;
-            log(errorMsg, 'error');
-            ui.notifications.error(
-                'MediaSoup: Failed to consume media stream - server configuration error'
-            );
-            return;
-        }
-
-        if (
-            !this.isConnected ||
-            !this.recvTransport ||
-            !this.device.canConsume({ producerId, kind, rtpParameters: appData.rtpParameters })
-        ) {
-            const errorMsg = `Cannot consume new producer ${producerId}: Not ready or device cannot consume. Device consumable check failed.`;
-            log(errorMsg, 'warn');
-            ui.notifications.warn(
-                `MediaSoup: Unable to receive ${kind} stream from user - device not compatible`
-            );
+        if (!this.isConnected || !this.recvTransport || !this.device) {
+            log(`Cannot consume new producer ${producerId}: receive transport not ready.`, 'warn');
             return;
         }
         log(
@@ -856,8 +839,13 @@ export class MediaSoupVTTClient {
         );
 
         try {
+            // Ask the server to create a consumer. The server validates that our
+            // device can consume this producer (router.canConsume) using the
+            // rtpCapabilities we send, then returns the consumer parameters
+            // (including its own rtpParameters) needed to build the local consumer.
             const consumerParams = await this._sendSignalingRequest({
                 type: SIG_MSG_TYPES.CONSUME,
+                transportId: this.recvTransport.id,
                 producerId: producerId,
                 rtpCapabilities: this.device.rtpCapabilities,
             });
@@ -905,13 +893,6 @@ export class MediaSoupVTTClient {
             }
             this.remoteUserStreams.set(userId, userStreams);
 
-            if (consumerParams.producerPaused) {
-                log(
-                    `Remote producer ${producerId} is paused. Pausing consumer ${consumer.id}.`,
-                    'info'
-                );
-            }
-
             consumer.on('trackended', () => {
                 log(`Remote track ended for consumer ${consumer.id}.`, 'warn');
                 this._handleRemoteProducerClosed(consumer.producerId);
@@ -920,6 +901,19 @@ export class MediaSoupVTTClient {
                 log(`Consumer transport closed for consumer ${consumer.id}.`, 'warn');
                 this._handleRemoteProducerClosed(consumer.producerId);
             });
+
+            // The server creates consumers paused (mediasoup recommendation).
+            // Resume now that the local consumer and its media element are ready,
+            // otherwise no media ever flows and audio/video stays muted/black.
+            try {
+                await this._sendSignalingRequest({
+                    type: SIG_MSG_TYPES.CONSUMER_RESUME,
+                    consumerId: consumer.id,
+                });
+                log(`Resumed consumer ${consumer.id} on server.`, 'debug');
+            } catch (resumeError) {
+                log(`Failed to resume consumer ${consumer.id}: ${resumeError.message}`, 'warn');
+            }
 
             ui.players.render(true);
         } catch (error) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -8,6 +8,7 @@ export const LOG_PREFIX = `${MODULE_TITLE} |`;
 
 // Settings keys
 export const SETTING_MEDIASOUP_URL = 'mediaSoupServerUrl';
+export const SETTING_MEDIASOUP_AUTH_TOKEN = 'mediaSoupAuthToken';
 export const SETTING_AUTO_CONNECT = 'autoConnect';
 export const SETTING_DEFAULT_AUDIO_DEVICE = 'defaultAudioDevice';
 export const SETTING_DEFAULT_VIDEO_DEVICE = 'defaultVideoDevice';
@@ -27,6 +28,7 @@ export const SIGNALING_REQUEST_TIMEOUT_MS = 10000;
 
 // Signaling message types
 export const SIG_MSG_TYPES = {
+    AUTHENTICATE: 'authenticate',
     GET_ROUTER_RTP_CAPABILITIES: 'getRouterRtpCapabilities',
     ROUTER_RTP_CAPABILITIES: 'routerRtpCapabilities',
     CREATE_WEBRTC_TRANSPORT: 'createWebRtcTransport',

--- a/src/ui/settings.js
+++ b/src/ui/settings.js
@@ -9,6 +9,7 @@ import {
     SETTING_DEBUG_LOGGING,
     SETTING_DEFAULT_AUDIO_DEVICE,
     SETTING_DEFAULT_VIDEO_DEVICE,
+    SETTING_MEDIASOUP_AUTH_TOKEN,
     SETTING_MEDIASOUP_URL,
 } from '../constants/index.js';
 import { log } from '../utils/logger.js';
@@ -41,6 +42,25 @@ export function registerSettings() {
                         `${MODULE_TITLE}: Server URL changed. Disconnected. Please reconnect manually.`
                     );
                 }
+            }
+        },
+    });
+
+    game.settings.register(MODULE_ID, SETTING_MEDIASOUP_AUTH_TOKEN, {
+        name: 'MediaSoup Server Auth Token',
+        hint: 'Shared secret required by the MediaSoup server (matches its MEDIASOUP_AUTH_TOKEN). Leave blank if the server runs without authentication. Note: stored as a world setting, so all players in the world can read it.',
+        scope: 'world',
+        config: true,
+        type: String,
+        default: '',
+        onChange: (value) => {
+            log(`MediaSoup auth token changed (length: ${value ? value.length : 0})`);
+            const clientInstance = window.MediaSoupVTT_Client;
+            if (clientInstance && (clientInstance.isConnected || clientInstance.isConnecting)) {
+                clientInstance.disconnect();
+                ui.notifications?.info(
+                    `${MODULE_TITLE}: Auth token changed. Disconnected. Please reconnect manually.`
+                );
             }
         },
     });


### PR DESCRIPTION
## Summary

Works through the critical (🔴) open issues.

### #115 — Client/server signaling protocol mismatch (root cause)
The JS client and Rust server spoke two different wire formats, so every signaling request timed out and no A/V connection could complete. Per the issue's recommended **Option A**, the server now speaks the client's flat envelope:

- Requests parsed as `{ type, requestId, userId, <flat fields> }` via a new `IncomingMessage` (serde `flatten`) instead of `{ id, method, data }`.
- Responses sent as `{ requestId, data }` / `{ requestId, error }`; notifications as `{ type, <flat fields> }` via a new `OutgoingMessage`.
- Removed the dead `SignalingMessage`/`SignalingRequest`/`SignalingMethod` typed layer.

### #116 — Consume path repaired (remote media now flows)
- `kind` serialized lowercase (`audio`/`video`) on the `newProducer` notification and consume response.
- `newProducer` uses flat `producerId`/`userId`/`kind` so the client's cleanup keys line up.
- Consumers created **paused** + new `consumerResume` handler; the client resumes after wiring up the local consumer.
- Client no longer requires `rtpParameters` in the notification or calls the non-existent `device.canConsume()`; it sends `transportId` with the consume request.
- `remove_peer` broadcasts `producerClosed` **before** `Peer::close` clears the producer map.

### #117 — CHANGELOG merge-conflict markers
Removed the committed diff3 conflict markers.

### #118 — Authentication + TLS
- **Auth (shared-secret gate, "token now, relay later"):** server requires an `authenticate` handshake as the first WebSocket frame; shared secret via `MEDIASOUP_AUTH_TOKEN`, constant-time compared. Authenticated peer identity is the FoundryVTT `userId` (not a random UUID). Client sends the token from a new world-scoped `mediaSoupAuthToken` setting. `verify_token` is the single seam to later adopt relay-minted per-user tokens (the agreed follow-up).
- **TLS (both styles):** optional native rustls termination (`wss://`) when `MEDIASOUP_TLS_CERT`/`MEDIASOUP_TLS_KEY` are set; otherwise plain `ws://` behind a reverse proxy. Connection handling made generic over the stream type. Uses the `ring` provider (no cmake/aws-lc-rs).
- Honest application-security section added to `SECURITY_AUDIT.md`; env wired into `docker-compose.yml`; unit tests for the constant-time compare.

## Verification
- `cargo test` ✅ (6 tests: 2 auth unit + 4 signaling integration), `cargo build --release` ✅
- `npm run build` / `build:test` ✅, `biome check .` ✅ (#120 already green on this branch)

## CI triage (per maintainer request)
- **MediaSoup Server Tests** — was failing because the old test used the removed `SignalingMessage` API; rewritten against the new envelope.
- **Security Audit** (npm-audit, pre-existing) → filed #128.
- **Smoke Tests (windows-latest)** (Playwright flakiness, pre-existing) → filed #129.

Closes #115, #116, #117, #118

https://claude.ai/code/session_01JPqWdN3JCEwYHiuJcgA136