### PR TITLE
chore(scripts): use a generic placeholder for the repo-name fallback

### DIFF
--- a/scripts/process-template.cjs
+++ b/scripts/process-template.cjs
@@ -30,7 +30,7 @@ function getGitRemoteInfo() {
         console.warn('Could not parse git remote URL');
     }
 
-    return { username: 'yourusername', repository: 'foundryvtt-webrtc-mediasoup' };
+    return { username: 'yourusername', repository: 'your-repository' };
 }
 
 function getPackageVersion() {


### PR DESCRIPTION
## What

`getGitRemoteInfo()` in `scripts/process-template.cjs` had a detection-failure
fallback that hardcoded a specific, stale repository name
(`foundryvtt-webrtc-mediasoup`) beside a generic `username: 'yourusername'`
placeholder.

## Why

- This repo is `laurigates/foundryvtt-mediasoup-webrtc` — the hardcoded name was wrong.
- A specific repo name in a "remote URL couldn't be parsed" fallback is wrong for any fork regardless.
- Inconsistent with the adjacent `yourusername` placeholder and the file's other placeholders (`Your Name`, `your.email@example.com`).

## How

Use a generic `your-repository` placeholder. This branch only fires when the git
remote can't be parsed; normal builds derive the real values from the remote URL,
so the shipped `module.json` is unaffected.

Surfaced while reorganizing the local `foundryvtt-dev/` workspace (the working-copy
directory was renamed to match this repo's canonical name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8zM5SezisjSDrLRGf4UbW
