### PR TITLE
chore(claude): allow scheduling and notification tools without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,12 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "PushNotification",
+      "RemoteTrigger",
+      "ScheduleWakeup",
       "Bash(git:*)",
       "Bash(gh:*)",
       "Bash(pre-commit:*)",


### PR DESCRIPTION
## What

Adds six bare tool-name entries to `permissions.allow` in `.claude/settings.json`:

`CronCreate` · `CronDelete` · `CronList` · `PushNotification` · `RemoteTrigger` · `ScheduleWakeup`

## Why

Under `permissions.defaultMode: "auto"`, `CronCreate`, `RemoteTrigger`, and `ScheduleWakeup` belong to a hardcoded always-classify tool set in the Claude Code CLI. That set is consulted *before* the "would this be allowed in acceptEdits mode?" fast path, so the fast path never runs for them and every call is routed to the auto-mode classifier — producing a constant stream of approve/deny prompts for routine check-back-in machinery (arm a cron, arm a claude.ai routine, notify when CI finishes). Unattended sessions stall on them.

A whole-tool allow rule resolves *before* the classifier, and none of these tools declares `ignoresWholeToolAllowRule`, so bare tool-name entries clear the prompts. None of the six executes shell, edits files, or reaches the network beyond the claude.ai routines API.

`Monitor` is deliberately excluded — it runs arbitrary shell.

## Why the project file and not just `~/.claude`

Claude Code web/remote sessions have no access to the global `~/.claude` overlay, so a committed project `.claude/settings.json` is the only place these rules reach them. The global overlay is handled separately in `laurigates/dotfiles`.

Part of a portfolio-wide sweep; identical change in each `laurigates` repo that has a committed `.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AF6S4A2q5ha5Yhk8duyMp
